### PR TITLE
fix(param) updated param name

### DIFF
--- a/contracts/AutoLooter.sol
+++ b/contracts/AutoLooter.sol
@@ -49,12 +49,12 @@ contract AutoLooter is Ownable {
 
     constructor(
         address _factory,
-        address _lootChest,
+        address _quest,
         address _govToken,
         address _weth
     ) public {
         factory = IUniswapV2Factory(_factory);
-        quest = _lootChest;
+        quest = _quest;
         govToken = _govToken;
         weth = _weth;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lootswap/contracts",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "license": "MIT",
   "description": "Loot Token + 🧑‍🌾 Liquidity Mining contracts for LootSwap & the LootSwap Protocol",
   "files": [


### PR DESCRIPTION
updating init type hash on contract for a quick fix we will just change the init hash on the contract but for testing purposes we will need to have it be the same that is on the Test/Constant.spec.ts, also when we deploy to npm it will not have those test just so we can start working on new features ASAP. There is a TODO ticket created to fix this concern and find a better solution